### PR TITLE
chore: update obsidian-linter to 1.31.0

### DIFF
--- a/.obsidian/plugins/obsidian-linter/manifest.json
+++ b/.obsidian/plugins/obsidian-linter/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-linter",
   "name": "Linter",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "minAppVersion": "1.9.0",
   "description": "Formats and styles your notes. It can be used to format YAML tags, aliases, arrays, and metadata; footnotes; headings; spacing; math blocks; regular markdown contents like list, italics, and bold styles; and more with the use of custom rule options as well.",
   "author": "Victor Tao",


### PR DESCRIPTION
## Summary

- Update Obsidian Linter plugin from v1.30.0 to v1.31.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)