### PR TITLE
Converge typography and palette with crbgc.org

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
+  "files": {
+    "includes": ["custom.css"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/config.json
+++ b/config.json
@@ -1,21 +1,21 @@
 {
-	"title": "C&RBGC Notes",
-	"description": "Notes on golf — its history, its architects, its courses, and especially the walking, hickory-era version of the game.",
-	"nav": {
-		"title": "C&RBGC Notes",
-		"links": [
-			{ "href": "https://crbgc.org", "name": "Club" },
-			{ "href": "/Game Philosophy", "name": "Game Philosophy" },
-			{ "href": "/Course Architecture", "name": "Course Architecture" },
-			{ "href": "/Courses to Play", "name": "Courses to Play" },
-			{ "href": "/Hickory Era", "name": "Hickory Era" },
-			{ "href": "/History", "name": "History" }
-		]
-	},
-	"showSidebar": true,
-	"theme": {
-		"theme": "letterpress",
-		"defaultMode": "light",
-		"showModeSwitch": false
-	}
+  "title": "C&RBGC Notes",
+  "description": "Notes on golf — its history, its architects, its courses, and especially the walking, hickory-era version of the game.",
+  "nav": {
+    "title": "C&RBGC Notes",
+    "links": [
+      { "href": "https://crbgc.org", "name": "Club" },
+      { "href": "/Game Philosophy", "name": "Game Philosophy" },
+      { "href": "/Course Architecture", "name": "Course Architecture" },
+      { "href": "/Courses to Play", "name": "Courses to Play" },
+      { "href": "/Hickory Era", "name": "Hickory Era" },
+      { "href": "/History", "name": "History" }
+    ]
+  },
+  "showSidebar": true,
+  "theme": {
+    "theme": "letterpress",
+    "defaultMode": "light",
+    "showModeSwitch": false
+  }
 }

--- a/config.json
+++ b/config.json
@@ -1,17 +1,21 @@
 {
-  "title": "C&RBGC Notes",
-  "description": "Notes on golf — its history, its architects, its courses, and especially the walking, hickory-era version of the game.",
-  "theme": "letterpress",
-  "nav": {
-    "title": "C&RBGC Notes",
-    "links": [
-      { "href": "/Hickory Era", "name": "Hickory Era" },
-      { "href": "/Course Architecture", "name": "Course Architecture" },
-      { "href": "/Courses to Play", "name": "Courses to Play" },
-      { "href": "/Game Philosophy", "name": "Game Philosophy" },
-      { "href": "/History", "name": "History" },
-      { "href": "https://crbgc.org", "name": "Club" }
-    ]
-  },
-  "showSidebar": true
+	"title": "C&RBGC Notes",
+	"description": "Notes on golf — its history, its architects, its courses, and especially the walking, hickory-era version of the game.",
+	"nav": {
+		"title": "C&RBGC Notes",
+		"links": [
+			{ "href": "https://crbgc.org", "name": "Club" },
+			{ "href": "/Game Philosophy", "name": "Game Philosophy" },
+			{ "href": "/Course Architecture", "name": "Course Architecture" },
+			{ "href": "/Courses to Play", "name": "Courses to Play" },
+			{ "href": "/Hickory Era", "name": "Hickory Era" },
+			{ "href": "/History", "name": "History" }
+		]
+	},
+	"showSidebar": true,
+	"theme": {
+		"theme": "letterpress",
+		"defaultMode": "light",
+		"showModeSwitch": false
+	}
 }

--- a/custom.css
+++ b/custom.css
@@ -1,7 +1,7 @@
 :root {
   --color-l-background: #fafaf7;
   --color-l-foreground: #1a1a1a;
-  --color-l-accent: #2f5d3a;
+  --color-l-accent: #006747;
 
   --font-body: ui-serif, Georgia, Cambria, "Times New Roman", serif;
   --font-heading:

--- a/custom.css
+++ b/custom.css
@@ -1,49 +1,49 @@
 :root {
-	--color-l-background: #fafaf7;
-	--color-l-foreground: #1a1a1a;
-	--color-l-accent: #2f5d3a;
+  --color-l-background: #fafaf7;
+  --color-l-foreground: #1a1a1a;
+  --color-l-accent: #2f5d3a;
 
-	--font-body: ui-serif, Georgia, Cambria, "Times New Roman", serif;
-	--font-heading:
-		ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-body: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+  --font-heading:
+    ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
 
-	--font-size-base: 1.0625rem;
-	--line-height-normal: 1.6;
-	--font-size-h1: calc(var(--font-size-base) * 1.765);
-	--font-size-h2: calc(var(--font-size-base) * 1.294);
-	--font-size-h3: var(--font-size-base);
+  --font-size-base: 1.0625rem;
+  --line-height-normal: 1.6;
+  --font-size-h1: calc(var(--font-size-base) * 1.765);
+  --font-size-h2: calc(var(--font-size-base) * 1.294);
+  --font-size-h3: var(--font-size-base);
 }
 
 /* Links: green underline, 2px offset, drop on hover */
-.prose a,
-article a {
-	color: var(--color-accent);
-	text-decoration: underline;
-	text-underline-offset: 2px;
+article a,
+.prose a {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
-.prose a:hover,
-article a:hover {
-	text-decoration: none;
+article a:hover,
+.prose a:hover {
+  text-decoration: none;
 }
 
 /* Blockquote: green left rule, muted italic */
 .prose blockquote {
-	border-left: 3px solid var(--color-accent);
-	font-style: italic;
-	color: var(--color-foreground-600, #595959);
+  border-left: 3px solid var(--color-accent);
+  font-style: italic;
+  color: var(--color-foreground-600, #595959);
 }
 
 /* Wordmark: suppress default logo image, style title to match club */
-.navbar img,
-nav img {
-	display: none;
+nav img,
+.navbar img {
+  display: none;
 }
-.navbar a[href="/"],
-nav a[href="/"] {
-	font-family: var(--font-heading);
-	font-size: 0.9rem;
-	letter-spacing: 0.08em;
-	text-transform: uppercase;
-	color: var(--color-foreground-600, #595959);
-	text-decoration: none;
+nav a[href="/"],
+.navbar a[href="/"] {
+  font-family: var(--font-heading);
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-foreground-600, #595959);
+  text-decoration: none;
 }

--- a/custom.css
+++ b/custom.css
@@ -3,6 +3,10 @@
   --color-l-foreground: #1a1a1a;
   --color-l-accent: #006747;
 
+  /* Explicit unprefixed aliases so the override rules below resolve even
+     if the theme doesn't remap --color-l-* (light-only, set in config.json). */
+  --color-accent: #006747;
+
   --font-body: ui-serif, Georgia, Cambria, "Times New Roman", serif;
   --font-heading:
     ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;

--- a/custom.css
+++ b/custom.css
@@ -1,0 +1,49 @@
+:root {
+	--color-l-background: #fafaf7;
+	--color-l-foreground: #1a1a1a;
+	--color-l-accent: #2f5d3a;
+
+	--font-body: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+	--font-heading:
+		ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+
+	--font-size-base: 1.0625rem;
+	--line-height-normal: 1.6;
+	--font-size-h1: calc(var(--font-size-base) * 1.765);
+	--font-size-h2: calc(var(--font-size-base) * 1.294);
+	--font-size-h3: var(--font-size-base);
+}
+
+/* Links: green underline, 2px offset, drop on hover */
+.prose a,
+article a {
+	color: var(--color-accent);
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+.prose a:hover,
+article a:hover {
+	text-decoration: none;
+}
+
+/* Blockquote: green left rule, muted italic */
+.prose blockquote {
+	border-left: 3px solid var(--color-accent);
+	font-style: italic;
+	color: var(--color-foreground-600, #595959);
+}
+
+/* Wordmark: suppress default logo image, style title to match club */
+.navbar img,
+nav img {
+	display: none;
+}
+.navbar a[href="/"],
+nav a[href="/"] {
+	font-family: var(--font-heading);
+	font-size: 0.9rem;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--color-foreground-600, #595959);
+	text-decoration: none;
+}


### PR DESCRIPTION
Aligns the notes site with crbgc.org (canonical for type and color).

Changes
- custom.css: ports club tokens — serif body / sans heading, #fafaf7 bg, #1a1a1a ink, #006747 Masters-green accent (replaces orange); link and blockquote treatment to match; suppresses the default logo image and styles the text wordmark like .site-title on the club.
- config.json: Letterpress theme, light-only (showModeSwitch off).

Intentional divergence
- Wider measure retained — survey essays and tables need the room.

Verify after first publish (Flowershow DOM classes are undocumented)
- [ ] Logo image hidden; text wordmark renders uppercase/letter-spaced
- [ ] Prose links are green, underlined, drop on hover
- [ ] Blockquote shows green left rule
- [ ] Home-link href is exactly "/"; if not, widen selector to nav a[href*="crbgc-philoserf"]
