### PR TITLE
Rename nav loop variable that shadowed link()

### DIFF
--- a/.scripts/gen-llms.py
+++ b/.scripts/gen-llms.py
@@ -85,8 +85,8 @@ def main() -> int:
     title = config.get("title", "Notes")
     blurb = config.get("description", "").strip()
     nav_order = [
-        link["href"].lstrip("/")
-        for link in config.get("nav", {}).get("links", [])
+        nav_link["href"].lstrip("/")
+        for nav_link in config.get("nav", {}).get("links", [])
     ]
 
     notes = {}


### PR DESCRIPTION
The `nav_order` comprehension in `main()` used `link` as its loop variable, shadowing the module-level `link()` helper. Safe today only because comprehensions have their own scope; a rewrite to a plain `for` loop would have leaked the name and silently broken the later `link(s, notes[s])` calls. Renamed to `nav_link`. Verified `task llms` output is byte-identical.

Closes #20

https://claude.ai/code/session_01VhF97sSgVSffy6B3bEa4xN