### PR TITLE
Address Copilot review comments from PRs #21–#23

### DIFF
--- a/.scripts/gen-llms.py
+++ b/.scripts/gen-llms.py
@@ -13,7 +13,13 @@ import sys
 import urllib.parse
 from pathlib import Path
 
-import yaml
+try:
+    import yaml
+except ImportError:
+    sys.exit(
+        "gen-llms.py needs PyYAML. The Homebrew python3 ships it; otherwise: "
+        "python3 -m pip install pyyaml"
+    )
 
 BASE = "https://crbgc-philoserf.flowershow.me"
 GOVERNANCE_SITE = "https://crbgc.org"
@@ -22,15 +28,18 @@ ROOT = Path(__file__).resolve().parent.parent
 
 # The Flowershow plugin's excludePatterns is the single source of truth for
 # what publishes. Its config is gitignored (it holds a token), so fall back
-# to a mirror of the list when it is absent; the mirror only needs the
-# patterns that can match *.md at the vault root.
+# to a mirror of that list when it is absent. Only patterns that can match
+# *.md at the vault root have any effect here, but the full list is kept so
+# the mirror stays a recognizable copy of the plugin's.
 PLUGIN_DATA = ROOT / ".obsidian" / "plugins" / "flowershow" / "data.json"
 FALLBACK_PATTERNS = (
     r"^CLAUDE\.md$",
     r"^_",
     r"^Drafts/",
     r"^Private/",
-    r"Rules of Golf\.md",
+    r"^Taskfile\.yml$",
+    r"^crbgc\.code-workspace$",
+    r"^Rules of Golf\.md$",
 )
 
 
@@ -53,7 +62,9 @@ def excluded(path: str) -> bool:
 
 def frontmatter(path: Path) -> dict:
     text = path.read_text(encoding="utf-8")
-    m = re.match(r"^---\n(.*?)\n---", text, re.S)
+    # Close only on a standalone --- or ... line, so a ----prefixed line
+    # inside a value cannot truncate the block.
+    m = re.match(r"\A---\n(.*?)\n(?:---|\.\.\.)[ \t]*(?:\n|\Z)", text, re.S)
     if not m:
         return {}
     try:
@@ -66,7 +77,9 @@ def frontmatter(path: Path) -> dict:
     d = {}
     for key in ("title", "description"):
         if data.get(key) is not None:
-            d[key] = str(data[key]).strip()
+            # Collapse whitespace so a multi-line YAML scalar cannot break
+            # the one-line-per-note llms.txt format.
+            d[key] = " ".join(str(data[key]).split())
     tags = data.get("tags") or []
     if isinstance(tags, str):
         tags = [tags]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ The directory is also an Obsidian vault (`.obsidian/`), so markdown is typically
 ### Site Configuration
 
 - `config.json`—Flowershow site config: title, nav (one link per primary index hub), footer, theme (`letterpress`, light-only). Adding a topic area means a new index note (tagged `index`) and, if it belongs in the navbar, a nav entry here.
-- `llms.txt`—generated, not hand-edited. `task llms` runs `.scripts/gen-llms.py`, which rebuilds it from `config.json` (title, blurb, hub order from nav) and each note's frontmatter (titles, descriptions, `index` tag). Flowershow serves it at `/llms.txt`. Run `task llms` after adding, renaming, or re-describing notes, before publishing. The script reads the plugin's `excludePatterns` directly, with a mirrored fallback for machines without the plugin config—keep the fallback in sync.
+- `llms.txt`—generated, not hand-edited. `task llms` runs `.scripts/gen-llms.py`, which rebuilds it from `config.json` (title, blurb, hub order from nav) and each note's frontmatter (titles, descriptions, `index` tag). Flowershow serves it at `/llms.txt`. Run `task llms` after adding, renaming, or re-describing notes, before publishing. The script reads the plugin's `excludePatterns` directly; a copy inside the script serves as fallback on machines without the plugin config (only its `*.md` root patterns matter there)—update the copy when the plugin list changes.
 - Publish excludes live in the plugin's `excludePatterns` (regex on vault-relative paths): currently `CLAUDE.md`, `Rules of Golf.md`, `Taskfile.yml`, `crbgc.code-workspace`, and anything starting `_`, `Drafts/`, or `Private/`. Anything else in the vault publishes.
 
 ### Backlog


### PR DESCRIPTION
The four backlog PRs (#21–#24) were merged before their Copilot review comments were read — this follow-up addresses all six comments. Left open for review.

**From #21:**
- `FALLBACK_PATTERNS` now anchors `^Rules of Golf\.md$` (a hypothetical "My Rules of Golf.md" no longer matches) and mirrors the plugin list exactly, including the non-md entries.
- The "only needs patterns that can match *.md" comment was inaccurate; reworded to say the full list is kept for recognizability but only root `*.md` patterns take effect.

**From #22:**
- CLAUDE.md now says only the fallback's `*.md` root patterns matter, so nobody tries to keep `Taskfile.yml`-style excludes "in sync" needlessly.

**From #23:**
- PyYAML import is guarded: missing dependency exits with an install hint instead of a bare ImportError.
- Frontmatter closes only on a standalone `---`/`...` delimiter line; a dash-prefixed line inside a block scalar can no longer truncate the block (regression-tested).
- `title`/`description` collapse internal whitespace, so a multi-line YAML scalar cannot break llms.txt's one-line-per-note format.

`task llms` output is byte-identical.

https://claude.ai/code/session_01VhF97sSgVSffy6B3bEa4xN