### PR TITLE
Enable RSS, pin garden defaults, and set an emoji favicon

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,6 @@
 {
   "title": "C&RBGC Notes",
   "description": "Notes on golf — its history, its architects, its courses, and especially the walking, hickory-era version of the game.",
-  "favicon": "⛳",
   "nav": {
     "title": "C&RBGC Notes",
     "links": [

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "title": "C&RBGC Notes",
   "description": "Notes on golf — its history, its architects, its courses, and especially the walking, hickory-era version of the game.",
+  "favicon": "⛳",
   "nav": {
     "title": "C&RBGC Notes",
     "links": [
@@ -35,6 +36,9 @@
     ]
   },
   "showSidebar": true,
+  "showToc": true,
+  "showBacklinks": true,
+  "enableRss": true,
   "theme": {
     "theme": "letterpress",
     "defaultMode": "light",


### PR DESCRIPTION
Reviewed the current [Flowershow config reference](https://flowershow.app/docs/reference/config-file) against our `config.json`.

**Added:**
- `enableRss: true` — feed generation for the garden
- `showToc: true`, `showBacklinks: true` — the defaults, pinned explicitly since backlinks are load-bearing for how the vault cross-links
- `favicon: "⛳"` — emoji favicon (Premium feature; harmlessly ignored on the free tier)

**Considered and skipped:**
- `contentExclude` — would duplicate the plugin's `excludePatterns`; keeping one source of truth
- `image` (default social card) — Premium, and no asset to point at yet
- `analytics` / `umami` / `giscus` comments / `enableSearch` — need accounts or Premium; easy to add later if wanted
- `sidebar.orderBy` — the vault is flat and filenames are the titles, so ordering is already effectively by title
- `showEditLink` / `showRawLink` — left at their false defaults

Existing text (title, description, nav labels, footer) read well against the docs; no changes there.

https://claude.ai/code/session_01VhF97sSgVSffy6B3bEa4xN